### PR TITLE
#49: don't prettier the lock file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,7 @@
 # Ignore artifacts:
 build
 coverage
+
+# This can cause Dependanbot PRs from merging due to formatting changes
+# automatically committed, unsigned
+pnpm-lock.yaml


### PR DESCRIPTION
The auto-formatting of the `pnpm-lock.yaml` file is preventing Dependabot PRs from being mergeable due to unsigned commits.

Fixes #49